### PR TITLE
Likes page and Chats page synced 

### DIFF
--- a/app/src/main/java/com/intermeet/android/ChatFragment.kt
+++ b/app/src/main/java/com/intermeet/android/ChatFragment.kt
@@ -1,6 +1,5 @@
 package com.intermeet.android
 
-import android.app.Dialog
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
@@ -8,9 +7,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
-import androidx.fragment.app.Fragment
-import android.widget.ListView
 import android.widget.EditText
+import android.widget.ListView
+import androidx.fragment.app.Fragment
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
@@ -43,7 +42,7 @@ class ChatFragment : Fragment() {
         // Set up your list view adapter and other UI interactions here
         val currentUser = getCurrentUserId()
         if (currentUser != null) {
-            fetchLikedUsers(currentUser) { users ->
+            fetchMapUsers(currentUser) { users ->
                 val adapter = ChatAdapter(requireContext(), users) { userId ->
                     startChatWithUser(userId)
                 }
@@ -69,11 +68,11 @@ class ChatFragment : Fragment() {
         return currentUser?.uid
     }
 
-    private fun fetchLikedUsers(userID: String, callback: (List<String>) -> Unit) {
-        val userRef = FirebaseDatabase.getInstance().getReference("users").child(userID).child("likes")
+    private fun fetchMapUsers(userID: String, callback: (List<String>) -> Unit) {
+        val userRef = FirebaseDatabase.getInstance().getReference("users").child(userID).child("matches")
         userRef.addListenerForSingleValueEvent(object : ValueEventListener {
             override fun onDataChange(snapshot: DataSnapshot) {
-                val likedUserIds = snapshot.children.mapNotNull { it.key }
+                val likedUserIds = snapshot.children.mapNotNull { it.value.toString() }
                 callback(likedUserIds)
             }
 

--- a/app/src/main/java/com/intermeet/android/DiscoverViewModel.kt
+++ b/app/src/main/java/com/intermeet/android/DiscoverViewModel.kt
@@ -1,8 +1,9 @@
 package com.intermeet.android
 
 import android.content.ContentValues.TAG
+import android.os.Build
 import android.util.Log
-import androidx.lifecycle.LiveData
+import androidx.annotation.RequiresApi
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -16,7 +17,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import queryNearbyUsers
-import java.time.Instant
 import java.time.LocalDate
 import java.time.Period
 import java.time.format.DateTimeFormatter
@@ -46,6 +46,7 @@ class DiscoverViewModel : ViewModel() {
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     fun fetchAndFilterUsers() {
         fetchCurrentUserLocationAndQueryNearbyUsers()  // Fetch nearby users first
         _nearbyUserIdsLiveData.observeForever { userIds ->
@@ -94,6 +95,7 @@ class DiscoverViewModel : ViewModel() {
         })
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun filterUserIdsByPreference(userIds: List<String>) {
         viewModelScope.launch {
             val currentUser = fetchCurrentUserPreferences()
@@ -145,6 +147,7 @@ class DiscoverViewModel : ViewModel() {
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun userMeetsPreferences(user: UserDataModel, currentUser: UserDataModel): Boolean {
 
         val preferenceFields = listOf(
@@ -191,6 +194,7 @@ class DiscoverViewModel : ViewModel() {
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun ageWithinRange(birthday: String?, minAge: Int?, maxAge: Int?): Boolean {
         if (birthday == null) return false
         return try {

--- a/app/src/main/java/com/intermeet/android/LikesDetailFragment.kt
+++ b/app/src/main/java/com/intermeet/android/LikesDetailFragment.kt
@@ -235,7 +235,7 @@ class LikesDetailFragment : Fragment() {
     }
 
     companion object {
-        private const val ARG_USER_ID = "user_id"
+        const val ARG_USER_ID = "user_id"
 
         fun newInstance(userId: String) =
             LikesDetailFragment().apply {

--- a/app/src/main/java/com/intermeet/android/LikesPageAdapter.kt
+++ b/app/src/main/java/com/intermeet/android/LikesPageAdapter.kt
@@ -1,78 +1,23 @@
 package com.intermeet.android
 
-import android.content.Context
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import android.widget.ArrayAdapter
-import android.widget.ImageView
-import android.widget.TextView
-import androidx.recyclerview.widget.RecyclerView
-import androidx.recyclerview.widget.RecyclerView.ViewHolder
-import com.bumptech.glide.Glide
-import com.google.firebase.database.DataSnapshot
-import com.google.firebase.database.DatabaseError
-import com.google.firebase.database.FirebaseDatabase
-import com.google.firebase.database.ValueEventListener
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
 
-class LikesPageAdapter(context: Context, private val likesuser_list: List<String>) : ArrayAdapter<String>(context, R.layout.likes_user_item, likesuser_list)
-{
-    override fun getCount(): Int {
-        return likesuser_list.size
+class LikesPageAdapter(fragment: Fragment, userId: String) : FragmentStateAdapter(fragment) {
+    private var userIds = emptyList<String>()
+    private var likes_userId = userId
+
+    fun setUserIds(newIds: List<String>) {
+        userIds = newIds
     }
 
-    override fun getItem(position: Int): String? {
-        return super.getItem(position)
+    override fun getItemCount(): Int = userIds.size
+
+    override fun createFragment(position: Int): Fragment {
+        return UserDetailFragment.newInstance(likes_userId)
     }
 
-    override fun getItemId(position: Int): Long {
-        return super.getItemId(position)
-    }
-
-    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
-        var viewItem = convertView
-        val viewHolder : ViewHolder
-
-        if(viewItem == null)
-        {
-            viewItem = LayoutInflater.from(context).inflate(R.layout.likes_user_item, parent, false)
-            viewHolder = ViewHolder()
-            viewHolder.likesuser_image = viewItem.findViewById(R.id.likespage_image)
-            viewItem.tag = viewHolder
-        }
-        else {
-            viewHolder = viewItem.tag as ViewHolder
-        }
-
-        val likesuser = likesuser_list[position]
-
-
-        val dbReference = FirebaseDatabase.getInstance().getReference("users/$likesuser")
-        dbReference.addValueEventListener(object : ValueEventListener
-        {
-            override fun onDataChange(snapshot: DataSnapshot) {
-                val userData = snapshot.getValue(UserData::class.java)
-
-                userData?.let{ user ->
-                    val image = user.photoDownloadUrls
-
-                    Glide.with(context)
-                        .load(image?.first())
-                        .into(viewHolder.likesuser_image)
-                }
-            }
-
-            override fun onCancelled(error: DatabaseError) {
-                TODO("Not yet implemented")
-            }
-        })
-
-        return viewItem!!
-    }
-
-    // ViewHolder pattern for efficient view recycling
-    private class ViewHolder {
-        lateinit var likesuser_image: ImageView
-        //lateinit var likesuser_name: TextView
+    fun getUserId(position: Int): String {
+        return userIds[position]
     }
 }

--- a/app/src/main/java/com/intermeet/android/LikesPageFragment.kt
+++ b/app/src/main/java/com/intermeet/android/LikesPageFragment.kt
@@ -1,4 +1,5 @@
 //import com.intermeet.android.DiscoverFragment
+import android.content.ContentValues.TAG
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -13,7 +14,6 @@ import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
 import com.intermeet.android.DiscoverActivity
-import com.intermeet.android.LikesDetailFragment
 import com.intermeet.android.R
 import com.intermeet.android.UserDetailAdapter
 
@@ -51,7 +51,8 @@ class LikesPageFragment(private var recyclerDataArrayList: List<String>) : Fragm
 
                 adapter.setOnClickListener(object : RecyclerViewAdapter.OnClickDetect {
                     override fun onClickDetect(position: Int, userId: String) {
-                        val likesDetailFragment = LikesDetailFragment.newInstance(userId)
+                        Log.d(TAG, "Clicking on userId: " + userId)
+                        val likesDetailFragment = LikesFragment.newInstance(userId)
                         parentFragmentManager.beginTransaction()
                             .replace(R.id.fragmentContainer, likesDetailFragment)
                             .addToBackStack(null)  // Optional: Add transaction to the back stack

--- a/app/src/main/res/layout/fragment_likes_detail.xml
+++ b/app/src/main/res/layout/fragment_likes_detail.xml
@@ -12,8 +12,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-
-
         <TextView
             android:id="@+id/frame_2"
             android:layout_width="177dp"

--- a/app/src/main/res/layout/fragment_likes_prepage.xml
+++ b/app/src/main/res/layout/fragment_likes_prepage.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/usersViewPager"
+        android:layout_width="match_parent"
+        android:layout_height="687dp"
+        android:layout_below="@+id/frame_2"
+        android:layout_marginTop="-38dp" />
+
+    <!--<View
+        android:id="@+id/return_button"
+        android:layout_width="40dp"
+        android:layout_height="38dp"
+        android:background="@drawable/resource_return"
+        android:layout_marginEnd="48dp"
+        android:layout_marginTop="45dp"
+        android:layout_marginStart="23dp"/>-->
+
+    <View
+        android:id="@+id/retrieve_lastuser"
+        android:layout_width="40dp"
+        android:layout_height="38dp"
+        android:background="@drawable/arrow_return"
+        android:layout_marginEnd="48dp"
+        android:layout_marginTop="45dp"
+        android:layout_marginStart="23dp"/>
+
+    <TextView
+        android:id="@+id/frame_2"
+        android:layout_width="177dp"
+        android:layout_height="38dp"
+        android:background="@drawable/discover_bar"
+        android:gravity="center_horizontal"
+        android:layout_centerHorizontal="true"
+        android:text="@string/likes"
+        android:textColor="@color/white"
+        android:layout_margin="45dp"
+        android:textSize="30sp" />
+
+    <TextView
+        android:id="@+id/tvNoUsers"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/no_users"
+        android:layout_centerInParent="true"
+        android:visibility="gone"
+        android:textSize="18sp"
+        android:padding="16dp" />
+
+    <Button
+        android:id="@+id/btnLike"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="72dp"
+        android:text="Like" />
+
+    <Button
+        android:id="@+id/btnRefresh"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvNoUsers"
+        android:text="@string/review"
+        android:visibility="gone"
+        android:layout_centerHorizontal="true"/>
+
+    <Button
+        android:id="@+id/btnPass"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="72dp"
+        android:text="Pass" />
+
+    <ProgressBar
+        android:id="@+id/loadingProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        style="@android:style/Widget.DeviceDefault.Light.ProgressBar.Large"
+        android:indeterminate="true"
+        android:visibility="gone" />
+</RelativeLayout>
+


### PR DESCRIPTION
chat should only disply users that are matched with the current user.
when a user is liked on the like page, that user would b added in the currents user's match field in the db, and vice versa
it would then lead the current user to the chat where they can chat with the user they just matched with 

(need to understand the other functions built into the LikesFragment adapter as some of them I believe are not necessary)